### PR TITLE
Don't send IsActive on create, it's set by default

### DIFF
--- a/pkg/connector/client/salesforce.go
+++ b/pkg/connector/client/salesforce.go
@@ -654,7 +654,6 @@ func (c *SalesforceClient) AddUserToPermissionSet(
 		map[string]interface{}{
 			"AssigneeId":      userId,
 			"PermissionSetId": permissionSetId,
-			"IsActive":        1,
 		},
 	)
 }

--- a/test/fixtures/dump.sql
+++ b/test/fixtures/dump.sql
@@ -17,7 +17,7 @@ CREATE TABLE PermissionSetAssignment (
     Id TEXT PRIMARY KEY,
     PermissionSetId TEXT,
     AssigneeId TEXT,
-    IsActive INT
+    IsActive INT DEFAULT 1
 );
 
 CREATE TABLE PermissionSet (


### PR DESCRIPTION
This errored on provisioning. I set IsActive to 1 previously to make a test pass but the actual API errors if you try to pass this field on provisioning. Instead I remove the field on create and set the ramdb schema to have a default so the test stops failing without breaking the actual connector.

#### Description

- [ ] Bug fix
- [ ] New feature

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
