### PR TITLE
baton-salesforce: add permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,6 @@ permissions:
   deployments: write
   discussions: write
   issues: write
-  metadata: read
   packages: write
   pages: write
   pull-requests: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,20 @@
 name: ci
 on: pull_request
 permissions:
+  actions: write
+  attestations: write
+  checks: write
   contents: write
+  deployments: write
+  discussions: write
+  issues: write
+  metadata: read
+  packages: write
+  pages: write
+  pull-requests: write
+  repository-projects: write
+  security-events: write
+  statuses: write
 jobs:
   go-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
 name: ci
 on: pull_request
+permissions:
+  contents: write
 jobs:
   go-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Description
<img width="390" alt="image" src="https://github.com/user-attachments/assets/6c1325ee-22ef-4387-a0a4-7bbe8c7bef78" />

<img width="282" alt="image" src="https://github.com/user-attachments/assets/bf764bd0-ff19-48c2-a9c8-062646cd42c9" />


Looks like the github_token has only read permission, that why the secrets don't pass in and the variables like `BATON_INSTANCE_URL` end up empty. 

I tried to override the permission with write permission.

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
