### PR TITLE
retry when getting users after provisioning

### DIFF
--- a/pkg/connector/client/user.go
+++ b/pkg/connector/client/user.go
@@ -7,6 +7,7 @@ import (
 	"net/mail"
 	"time"
 
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -71,6 +72,39 @@ func (c *SalesforceClient) UserExist(
 	}
 
 	return user != nil, nil
+}
+
+func (c *SalesforceClient) GetUserByEmailWithRetry(
+	ctx context.Context,
+	email string,
+) (
+	*SalesforceUser,
+	error,
+) {
+	maxRetries := 3
+	baseDelay := time.Second
+	var err error
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		// Clear cache or we won't get new responses
+		err = uhttp.ClearCaches(ctx)
+		if err != nil {
+			return nil, err
+		}
+		user, err := c.GetUserByEmail(ctx, email)
+		if err == nil {
+			return user, nil
+		}
+
+		if status.Code(err) != codes.NotFound {
+			return nil, err
+		}
+		// Wait before retrying with exponential backoff
+		delay := time.Duration(attempt+1) * baseDelay
+		time.Sleep(delay)
+	}
+
+	return nil, fmt.Errorf("failed to get user by email after %d retries", maxRetries)
 }
 
 func (c *SalesforceClient) GetUserByEmail(

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -10,7 +10,6 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
-	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 )
@@ -243,13 +242,7 @@ func (o *userBuilder) CreateAccount(
 		}
 	}
 
-	// Clear cache to find the new user by email, otherwise it will not be found
-	err = uhttp.ClearCaches(ctx)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	user, err := o.client.GetUserByEmail(ctx, userRequest.Email)
+	user, err := o.client.GetUserByEmailWithRetry(ctx, userRequest.Email)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
#### Description

When we provision a new user, we then check to make sure we made it properly. we have seen this check return NotFound before, but then we see the user in salesforce. lets retry w/ a wait a few times to try and make sure we find the user when a little delay would have found it.

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
