### PR TITLE
Add an option to turn off syncing deactivated users:

### DIFF
--- a/cmd/baton-salesforce/config.go
+++ b/cmd/baton-salesforce/config.go
@@ -30,6 +30,11 @@ var (
 		"sync-connected-apps",
 		field.WithDescription("Optionally sync access to connected apps"),
 	)
+	SyncDeactivatedUsers = field.BoolField(
+		"sync-deactivated-users",
+		field.WithDescription("Optionally sync deactivated users"),
+		field.WithDefaultValue(true),
+	)
 
 	configurationFields = []field.SchemaField{
 		InstanceUrlField,
@@ -38,6 +43,7 @@ var (
 		PasswordField,
 		SecurityTokenField,
 		SyncConnectedApps,
+		SyncDeactivatedUsers,
 	}
 
 	Configuration = field.NewConfiguration(

--- a/cmd/baton-salesforce/main.go
+++ b/cmd/baton-salesforce/main.go
@@ -55,6 +55,7 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 		v.GetString(PasswordField.FieldName),
 		v.GetString(SecurityTokenField.FieldName),
 		v.GetBool(SyncConnectedApps.FieldName),
+		v.GetBool(SyncDeactivatedUsers.FieldName),
 	)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))

--- a/pkg/connector/client/salesforce.go
+++ b/pkg/connector/client/salesforce.go
@@ -241,6 +241,7 @@ func (c *SalesforceClient) GetUsers(
 	ctx context.Context,
 	pageToken string,
 	pageSize int,
+	syncDeactivatedUsers bool,
 ) (
 	[]*SalesforceUser,
 	string,
@@ -265,6 +266,9 @@ func (c *SalesforceClient) GetUsers(
 		isActive, err := getIsActive(record)
 		if err != nil {
 			return nil, "", nil, err
+		}
+		if !syncDeactivatedUsers && !isActive {
+			continue
 		}
 		if shouldSkipSyncingUserType(ctx, record) {
 			continue

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -29,6 +29,7 @@ type Salesforce struct {
 	instanceURL               string
 	shouldUseUsernameForEmail bool
 	syncConnectedApps         bool
+	syncDeactivatedUsers      bool
 }
 
 // fallBackToHTTPS checks to domain and tacks on "https://" if no scheme is
@@ -52,7 +53,7 @@ func fallBackToHTTPS(domain string) (string, error) {
 // be synced from the upstream service.
 func (d *Salesforce) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
 	rv := []connectorbuilder.ResourceSyncer{
-		newUserBuilder(d.client, d.shouldUseUsernameForEmail),
+		newUserBuilder(d.client, d.shouldUseUsernameForEmail, d.syncDeactivatedUsers),
 		newGroupBuilder(d.client),
 		newPermissionBuilder(d.client),
 		newProfileBuilder(d.client),
@@ -214,6 +215,7 @@ func New(
 	password string,
 	securityToken string,
 	syncConnectedApps bool,
+	syncDeactivatedUsers bool,
 ) (*Salesforce, error) {
 	logger := ctxzap.Extract(ctx)
 	instanceURL, err := fallBackToHTTPS(instanceURL)
@@ -246,6 +248,7 @@ func New(
 		shouldUseUsernameForEmail: useUsernameForEmail,
 		instanceURL:               instanceURL,
 		syncConnectedApps:         syncConnectedApps,
+		syncDeactivatedUsers:      syncDeactivatedUsers,
 	}
 	return &salesforce, nil
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -18,6 +18,7 @@ type userBuilder struct {
 	resourceType              *v2.ResourceType
 	client                    *client.SalesforceClient
 	shouldUseUsernameForEmail bool
+	syncDeactivatedUsers      bool
 }
 
 // userResource convert a SalesforceUser into a Resource.
@@ -99,6 +100,7 @@ func (o *userBuilder) List(
 		ctx,
 		pToken.Token,
 		pToken.Size,
+		o.syncDeactivatedUsers,
 	)
 	outputAnnotations := client.WithRateLimitAnnotations(ratelimitData)
 	if err != nil {
@@ -282,10 +284,12 @@ func (o *userBuilder) CreateAccountCapabilityDetails(ctx context.Context) (*v2.C
 func newUserBuilder(
 	client *client.SalesforceClient,
 	shouldUseUsernameForEmail bool,
+	syncDeactivatedUsers bool,
 ) *userBuilder {
 	return &userBuilder{
 		resourceType:              resourceTypeUser,
 		client:                    client,
 		shouldUseUsernameForEmail: shouldUseUsernameForEmail,
+		syncDeactivatedUsers:      syncDeactivatedUsers,
 	}
 }

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -25,7 +25,7 @@ func TestUsersList(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c := newUserBuilder(salesforceClient, false)
+		c := newUserBuilder(salesforceClient, false, true)
 
 		resources := make([]*v2.Resource, 0)
 		pToken := pagination.Token{


### PR DESCRIPTION
#### Description
We want an option for syncing deactivated users so some users can turn it off.

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
