### PR TITLE
[CXP-218] Fix role revocation sending read-only fields to Salesforce

### DIFF
--- a/pkg/connector/client/request.go
+++ b/pkg/connector/client/request.go
@@ -229,7 +229,7 @@ func (c *SalesforceClient) setValue(
 
 	copySObject, err := c.copySObject(user, fieldName)
 	if err != nil {
-		return nil, err
+		return ratelimitData, err
 	}
 
 	return c.updateUser(ctx, copySObject, fieldName, fieldValue)
@@ -248,7 +248,7 @@ func (c *SalesforceClient) setOneValue(
 
 	copySObject, err := c.copySObject(user, fieldName)
 	if err != nil {
-		return nil, err
+		return ratelimitData, err
 	}
 
 	return c.updateUser(ctx, copySObject, fieldName, fieldValue)
@@ -271,7 +271,7 @@ func (c *SalesforceClient) clearValue(
 
 	copySObject, err := c.copySObject(user, fieldName)
 	if err != nil {
-		return nil, err
+		return ratelimitData, err
 	}
 
 	return c.updateUser(ctx, copySObject, fieldName, "")

--- a/pkg/connector/client/request.go
+++ b/pkg/connector/client/request.go
@@ -227,7 +227,12 @@ func (c *SalesforceClient) setValue(
 		return ratelimitData, err
 	}
 
-	return c.updateUser(ctx, user, fieldName, fieldValue)
+	copySObject, err := c.copySObject(user, fieldName)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.updateUser(ctx, copySObject, fieldName, fieldValue)
 }
 
 func (c *SalesforceClient) setOneValue(
@@ -264,7 +269,12 @@ func (c *SalesforceClient) clearValue(
 		return nil, fmt.Errorf("missing %s: %s", fieldName, fieldValue)
 	}
 
-	return c.updateUser(ctx, user, fieldName, "")
+	copySObject, err := c.copySObject(user, fieldName)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.updateUser(ctx, copySObject, fieldName, "")
 }
 
 func (c *SalesforceClient) copySObject(obj *simpleforce.SObject, allowedFields ...string) (*simpleforce.SObject, error) {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -180,17 +180,16 @@ var updateUserStatusActionSchema = &v2.BatonActionSchema{
 	},
 }
 
-func (d *Salesforce) RegisterActionManager(ctx context.Context) (connectorbuilder.CustomActionManager, error) {
+func (d *Salesforce) GlobalActions(ctx context.Context, registry actions.ActionRegistry) error {
 	l := ctxzap.Extract(ctx)
 
-	actionManager := actions.NewActionManager(ctx)
-	err := actionManager.RegisterAction(ctx, "update_user_status", updateUserStatusActionSchema, d.updateUserStatus)
+	err := registry.Register(ctx, updateUserStatusActionSchema, d.updateUserStatus)
 	if err != nil {
 		l.Error("failed to register action", zap.Error(err))
-		return nil, err
+		return err
 	}
 
-	return actionManager, nil
+	return nil
 }
 
 // Validate is called to ensure that the connector is properly configured. It


### PR DESCRIPTION
Use copySObject in setValue and clearValue to send only the target field in update requests, preventing INVALID_FIELD_FOR_INSERT_UPDATE errors from Salesforce when read-only fields are included.

#### Description

- [x] Bug fix
- [ ] New feature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable user update operations with safer copy-handling and extra error checks to reduce risk of data corruption and improve failure handling.

* **Refactor**
  * Streamlined action registration and request flow for more consistent behavior and clearer error reporting across related workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->