### PR TITLE
docs: add troubleshooting for insufficient access rights error

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -49,7 +49,7 @@ Connector actions are custom capabilities that extend C1 automations with app-sp
 Configuring the connector requires you to pass in credentials generated in Salesforce. Gather these credentials before you move on. 
 
 <Warning>
-The connector user must have the **API Enabled** and **Manage Users** system permissions. If using provisioning, additional permissions are required. See [Troubleshooting](#when-i-try-to-sync-i-see-an-insufficient-access-rights-on-cross-reference-id-error) for the complete list of required permissions.
+The connector user must have the **API Enabled** and **Manage Users** system permissions. If syncing connected apps, also add **Customize Application**. If using provisioning, also add **Manage Roles and Role Hierarchy** and **Manage Groups**.
 </Warning>
 
 ### Enable API access and permissions for your Salesforce user
@@ -347,37 +347,27 @@ If you see this message, follow the instructions to [Enable API access for your 
 
 ### When I try to sync, I see an "insufficient access rights on cross-reference id" error
 
-Salesforce returns this error if the connector user does not have sufficient permissions to query the Salesforce objects that the connector needs:
+Salesforce returns this error if the connector user does not have sufficient permissions:
 
 ```bash
 {"error": "error: listing resources failed: rpc error: code = InvalidArgument desc = 400 Bad Request\n[simpleforce] Error. http code: 400 Error Message:  insufficient access rights on cross-reference id Error Code: INSUFFICIENT_ACCESS"}
 ```
 
-The connector queries setup objects (User, Profile, UserRole, Group, PermissionSet, etc.) that are controlled by **administrative permissions**, not standard object-level CRUD permissions. The connector user's profile or an assigned permission set must include the following administrative permissions:
+Create a Permission Set with the following system permissions and assign it to the connector user:
 
 **Required system permissions for sync:**
 
 | Permission | Purpose |
 | :--- | :--- |
 | API Enabled | Access Salesforce APIs |
-| Manage Users | Read user login status, user records, and related setup objects. This permission automatically includes View Setup and Configuration, View All Users, and other related permissions. |
-| Customize Application | Required only if syncing connected apps (`--sync-connected-apps`). Grants access to query the ConnectedApplication object. |
-
-<Tip>
-**Why is Manage Users required for sync?** The connector queries the UserLogin object to read user frozen/locked status, and Salesforce requires "Manage Users" to access UserLogin even for read-only operations. "Manage Users" also includes "View Setup and Configuration" and "View All Users", which are needed to read Profiles, Roles, Permission Sets, and Groups.
-</Tip>
+| Manage Users | Read users and setup objects |
+| Customize Application | Required only if syncing connected apps |
 
 **Additional permissions required for provisioning:**
-
-If you're using the connector for provisioning (granting/revoking access), the connector user also needs:
 
 | Permission | Purpose |
 | :--- | :--- |
 | Manage Roles and Role Hierarchy | Assign and revoke role assignments |
 | Manage Groups | Add and remove users from public groups |
-
-<Tip>
-"Manage Users" already includes "Assign Permission Sets" and "Manage Profiles and Permission Sets", so no additional permissions are needed for provisioning permission sets or profiles.
-</Tip>
 
 To fix this error, follow the instructions to [Enable API access and permissions for your Salesforce user](/baton/salesforce#enable-api-access-and-permissions-for-your-salesforce-user) to create a Permission Set with the required permissions and assign it to the connector user. 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -49,7 +49,7 @@ Connector actions are custom capabilities that extend C1 automations with app-sp
 Configuring the connector requires you to pass in credentials generated in Salesforce. Gather these credentials before you move on. 
 
 <Warning>
-The owner of a Salesforce user account with a profile that includes the **API Enabled** and **View Setup and Configuration** permissions must perform this task. Additionally, the connector user must have read access to all Salesforce objects that the connector queries. See [Troubleshooting](#when-i-try-to-sync-i-see-an-insufficient-access-rights-on-cross-reference-id-error) for the complete list of required object permissions.
+The owner of a Salesforce user account with a profile that includes the **API Enabled**, **View Setup and Configuration**, and **View All Users** permissions must perform this task. If using provisioning, additional permissions are required. See [Troubleshooting](#when-i-try-to-sync-i-see-an-insufficient-access-rights-on-cross-reference-id-error) for the complete list of required permissions.
 </Warning>
 
 ### Enable API access for your Salesforce user
@@ -346,42 +346,36 @@ If you see this message, follow the instructions to [Enable API access for your 
 
 ### When I try to sync, I see an "insufficient access rights on cross-reference id" error
 
-Salesforce returns this error if the user who is syncing does not have read access to all the Salesforce objects that the connector needs to query:
+Salesforce returns this error if the connector user does not have sufficient permissions to query the Salesforce objects that the connector needs:
 
 ```bash
 {"error": "error: listing resources failed: rpc error: code = InvalidArgument desc = 400 Bad Request\n[simpleforce] Error. http code: 400 Error Message:  insufficient access rights on cross-reference id Error Code: INSUFFICIENT_ACCESS"}
 ```
 
-This error typically occurs when the connector user has **API Enabled** but lacks object-level read permissions. The connector queries multiple Salesforce objects and their relationships, so the connector user's profile must have read access to all of them.
+The connector queries setup objects (User, Profile, UserRole, Group, PermissionSet, etc.) that are controlled by **administrative permissions**, not standard object-level CRUD permissions. The connector user's profile or an assigned permission set must include the following administrative permissions:
 
-**Required object permissions for sync:**
+**Required administrative permissions for sync:**
 
-| Object | Required Access |
+| Permission | Purpose |
 | :--- | :--- |
-| User | Read |
-| UserRole | Read |
-| Profile | Read |
-| UserLicense | Read |
-| PermissionSet | Read |
-| PermissionSetAssignment | Read |
-| PermissionSetGroup | Read |
-| PermissionSetGroupComponent | Read |
-| Group | Read |
-| GroupMember | Read |
-| UserLogin | Read |
-| ConnectedApplication | Read (only if using `--sync-connected-apps`) |
+| API Enabled | Access Salesforce APIs |
+| View Setup and Configuration | Read setup objects (Profiles, Roles, Permission Sets, Groups) |
+| View All Users | Read all user records and related data |
 
 **Additional permissions required for provisioning:**
 
 If you're using the connector for provisioning (granting/revoking access), the connector user also needs:
 
-| Object | Required Access |
+| Permission | Purpose |
 | :--- | :--- |
-| User | Read, Edit |
-| GroupMember | Read, Create, Delete |
-| PermissionSetAssignment | Read, Create, Delete |
+| Manage Users | Create and edit user records, assign profiles |
+| Manage Roles and Role Hierarchy | Assign and revoke role assignments |
+| Assign Permission Sets | Assign and revoke permission sets and permission set groups |
+| Manage Groups | Add and remove users from public groups |
 
-To fix this error:
+To fix this error, grant these permissions via the connector user's **Profile** or by assigning a **Permission Set**:
+
+**Option 1: Edit the connector user's Profile**
 
 <Steps>
 <Step>
@@ -397,16 +391,26 @@ Search for "profiles" and select **Profiles** from the search results.
 Locate the profile used by your connector user and click **Edit**.
 </Step>
 <Step>
-Scroll to the **Standard Object Permissions** section and ensure **Read** access is enabled for all required objects listed above.
-</Step>
-<Step>
-If using provisioning, also enable **Edit**, **Create**, and **Delete** permissions as listed above.
+In the **Administrative Permissions** section, enable the required permissions listed above.
 </Step>
 <Step>
 Click **Save**.
 </Step>
 </Steps>
 
-<Tip>
-If you cannot find an object in Standard Object Permissions, it may be in the **Custom Object Permissions** section, or you may need to use a Permission Set to grant access to that specific object.
-</Tip> 
+**Option 2: Create and assign a Permission Set**
+
+<Steps>
+<Step>
+In Salesforce Setup, search for "permission sets" and select **Permission Sets**.
+</Step>
+<Step>
+Click **New** to create a permission set (e.g., "ConductorOne Connector Access").
+</Step>
+<Step>
+Under **System Permissions**, enable the required permissions listed above.
+</Step>
+<Step>
+Save the permission set, then assign it to the connector user.
+</Step>
+</Steps> 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -49,36 +49,37 @@ Connector actions are custom capabilities that extend C1 automations with app-sp
 Configuring the connector requires you to pass in credentials generated in Salesforce. Gather these credentials before you move on. 
 
 <Warning>
-The owner of a Salesforce user account with a profile that includes the **API Enabled**, **View Setup and Configuration**, and **View All Users** permissions must perform this task. If using provisioning, additional permissions are required. See [Troubleshooting](#when-i-try-to-sync-i-see-an-insufficient-access-rights-on-cross-reference-id-error) for the complete list of required permissions.
+The connector user must have the **API Enabled** and **Manage Users** system permissions. If using provisioning, additional permissions are required. See [Troubleshooting](#when-i-try-to-sync-i-see-an-insufficient-access-rights-on-cross-reference-id-error) for the complete list of required permissions.
 </Warning>
 
-### Enable API access for your Salesforce user
+### Enable API access and permissions for your Salesforce user
 
-Before you begin, make sure that the Salesforce user who will set up the integration with C1 has a profile that includes the **API Enabled** and **View Setup and Configuration** permissions. 
-
-To edit a profile so that it includes the **API Enabled** and **View Setup and Configuration** permissions: 
+Before you begin, make sure that the Salesforce user who will set up the integration with C1 has the required system permissions. The recommended approach is to create a Permission Set and assign it to the connector user.
 
 <Steps>
 <Step>
-Log into Salesforce as an Administrator. 
+Log into Salesforce as an Administrator. Click the gear icon and select **Setup**. 
 </Step>
 <Step>
-Click the gear icon and select **Setup**. 
+Search for "permission sets" and select **Permission Sets**.
 </Step>
 <Step>
-Search for "profiles" and select **Profiles** from the search results. 
+Click **New** to create a permission set (e.g., "ConductorOne Connector Access").
 </Step>
 <Step>
-In the **User Profiles** list, locate the user profile you want to add the permission to and click **Edit**. 
+In the permission set, click **System Permissions**, then click **Edit**.
 </Step>
 <Step>
-Find the **Administrative Permissions** section of the page and click to select **API Enabled** and **View Setup and Configuration**. 
+Enable **API Enabled** and **Manage Users**. If using provisioning, also enable **Manage Roles and Role Hierarchy** and **Manage Groups**.
 </Step>
 <Step>
-Click **Save**. 
+Click **Save**.
+</Step>
+<Step>
+Click **Manage Assignments**, then **Add Assignment** to assign the permission set to the connector user.
 </Step>
 </Steps>
-Your user's profile can now access Salesforce APIs. 
+Your connector user now has the required permissions to sync Salesforce data. 
 
 ### Locate your Salesforce domain
 
@@ -354,13 +355,16 @@ Salesforce returns this error if the connector user does not have sufficient per
 
 The connector queries setup objects (User, Profile, UserRole, Group, PermissionSet, etc.) that are controlled by **administrative permissions**, not standard object-level CRUD permissions. The connector user's profile or an assigned permission set must include the following administrative permissions:
 
-**Required administrative permissions for sync:**
+**Required system permissions for sync:**
 
 | Permission | Purpose |
 | :--- | :--- |
 | API Enabled | Access Salesforce APIs |
-| View Setup and Configuration | Read setup objects (Profiles, Roles, Permission Sets, Groups) |
-| View All Users | Read all user records and related data |
+| Manage Users | Read user login status, user records, and related setup objects. This permission automatically includes View Setup and Configuration, View All Users, and other related permissions. |
+
+<Tip>
+**Why is Manage Users required for sync?** The connector queries the UserLogin object to read user frozen/locked status, and Salesforce requires "Manage Users" to access UserLogin even for read-only operations. "Manage Users" also includes "View Setup and Configuration" and "View All Users", which are needed to read Profiles, Roles, Permission Sets, and Groups.
+</Tip>
 
 **Additional permissions required for provisioning:**
 
@@ -368,30 +372,11 @@ If you're using the connector for provisioning (granting/revoking access), the c
 
 | Permission | Purpose |
 | :--- | :--- |
-| Manage Users | Create and edit user records, assign profiles |
 | Manage Roles and Role Hierarchy | Assign and revoke role assignments |
-| Assign Permission Sets | Assign and revoke permission sets and permission set groups |
 | Manage Groups | Add and remove users from public groups |
 
-To fix this error, create a Permission Set with the required permissions and assign it to the connector user:
+<Tip>
+"Manage Users" already includes "Assign Permission Sets" and "Manage Profiles and Permission Sets", so no additional permissions are needed for provisioning permission sets or profiles.
+</Tip>
 
-<Steps>
-<Step>
-Log into Salesforce as an Administrator. Click the gear icon and select **Setup**.
-</Step>
-<Step>
-Search for "permission sets" and select **Permission Sets**.
-</Step>
-<Step>
-Click **New** to create a permission set (e.g., "ConductorOne Connector Access").
-</Step>
-<Step>
-In the permission set, click **System Permissions**, then click **Edit**.
-</Step>
-<Step>
-Enable the required permissions listed above and click **Save**.
-</Step>
-<Step>
-Click **Manage Assignments**, then **Add Assignment** to assign the permission set to the connector user.
-</Step>
-</Steps> 
+To fix this error, follow the instructions to [Enable API access and permissions for your Salesforce user](/baton/salesforce#enable-api-access-and-permissions-for-your-salesforce-user) to create a Permission Set with the required permissions and assign it to the connector user. 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -373,44 +373,25 @@ If you're using the connector for provisioning (granting/revoking access), the c
 | Assign Permission Sets | Assign and revoke permission sets and permission set groups |
 | Manage Groups | Add and remove users from public groups |
 
-To fix this error, grant these permissions via the connector user's **Profile** or by assigning a **Permission Set**:
-
-**Option 1: Edit the connector user's Profile**
+To fix this error, create a Permission Set with the required permissions and assign it to the connector user:
 
 <Steps>
 <Step>
-Log into Salesforce as an Administrator.
+Log into Salesforce as an Administrator. Click the gear icon and select **Setup**.
 </Step>
 <Step>
-Click the gear icon and select **Setup**.
-</Step>
-<Step>
-Search for "profiles" and select **Profiles** from the search results.
-</Step>
-<Step>
-Locate the profile used by your connector user and click **Edit**.
-</Step>
-<Step>
-In the **Administrative Permissions** section, enable the required permissions listed above.
-</Step>
-<Step>
-Click **Save**.
-</Step>
-</Steps>
-
-**Option 2: Create and assign a Permission Set**
-
-<Steps>
-<Step>
-In Salesforce Setup, search for "permission sets" and select **Permission Sets**.
+Search for "permission sets" and select **Permission Sets**.
 </Step>
 <Step>
 Click **New** to create a permission set (e.g., "ConductorOne Connector Access").
 </Step>
 <Step>
-Under **System Permissions**, enable the required permissions listed above.
+In the permission set, click **System Permissions**, then click **Edit**.
 </Step>
 <Step>
-Save the permission set, then assign it to the connector user.
+Enable the required permissions listed above and click **Save**.
+</Step>
+<Step>
+Click **Manage Assignments**, then **Add Assignment** to assign the permission set to the connector user.
 </Step>
 </Steps> 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -49,7 +49,7 @@ Connector actions are custom capabilities that extend C1 automations with app-sp
 Configuring the connector requires you to pass in credentials generated in Salesforce. Gather these credentials before you move on. 
 
 <Warning>
-The owner of a Salesforce user account with a profile that includes the **API Enabled** and **View Setup and Configuration** permissions must perform this task.
+The owner of a Salesforce user account with a profile that includes the **API Enabled** and **View Setup and Configuration** permissions must perform this task. Additionally, the connector user must have read access to all Salesforce objects that the connector queries. See [Troubleshooting](#when-i-try-to-sync-i-see-an-insufficient-access-rights-on-cross-reference-id-error) for the complete list of required object permissions.
 </Warning>
 
 ### Enable API access for your Salesforce user
@@ -342,4 +342,71 @@ Salesforce returns this error if the user who is logging in with OAuth does not 
 {"code":2, "message":"error getting info from connectorClient: [simpleforce] Error. http code: 403 Error Message:  This feature is not currently enabled for this user. Error Code: FUNCTIONALITY_NOT_ENABLED"}
 ```
 
-If you see this message, follow the instructions to [Enable API access for your Salesforce user](/baton/salesforce#enable-api-access-for-your-salesforce-user) and then try logging in again. 
+If you see this message, follow the instructions to [Enable API access for your Salesforce user](/baton/salesforce#enable-api-access-for-your-salesforce-user) and then try logging in again.
+
+### When I try to sync, I see an "insufficient access rights on cross-reference id" error
+
+Salesforce returns this error if the user who is syncing does not have read access to all the Salesforce objects that the connector needs to query:
+
+```bash
+{"error": "error: listing resources failed: rpc error: code = InvalidArgument desc = 400 Bad Request\n[simpleforce] Error. http code: 400 Error Message:  insufficient access rights on cross-reference id Error Code: INSUFFICIENT_ACCESS"}
+```
+
+This error typically occurs when the connector user has **API Enabled** but lacks object-level read permissions. The connector queries multiple Salesforce objects and their relationships, so the connector user's profile must have read access to all of them.
+
+**Required object permissions for sync:**
+
+| Object | Required Access |
+| :--- | :--- |
+| User | Read |
+| UserRole | Read |
+| Profile | Read |
+| UserLicense | Read |
+| PermissionSet | Read |
+| PermissionSetAssignment | Read |
+| PermissionSetGroup | Read |
+| PermissionSetGroupComponent | Read |
+| Group | Read |
+| GroupMember | Read |
+| UserLogin | Read |
+| ConnectedApplication | Read (only if using `--sync-connected-apps`) |
+
+**Additional permissions required for provisioning:**
+
+If you're using the connector for provisioning (granting/revoking access), the connector user also needs:
+
+| Object | Required Access |
+| :--- | :--- |
+| User | Read, Edit |
+| GroupMember | Read, Create, Delete |
+| PermissionSetAssignment | Read, Create, Delete |
+
+To fix this error:
+
+<Steps>
+<Step>
+Log into Salesforce as an Administrator.
+</Step>
+<Step>
+Click the gear icon and select **Setup**.
+</Step>
+<Step>
+Search for "profiles" and select **Profiles** from the search results.
+</Step>
+<Step>
+Locate the profile used by your connector user and click **Edit**.
+</Step>
+<Step>
+Scroll to the **Standard Object Permissions** section and ensure **Read** access is enabled for all required objects listed above.
+</Step>
+<Step>
+If using provisioning, also enable **Edit**, **Create**, and **Delete** permissions as listed above.
+</Step>
+<Step>
+Click **Save**.
+</Step>
+</Steps>
+
+<Tip>
+If you cannot find an object in Standard Object Permissions, it may be in the **Custom Object Permissions** section, or you may need to use a Permission Set to grant access to that specific object.
+</Tip> 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -70,7 +70,7 @@ Click **New** to create a permission set (e.g., "ConductorOne Connector Access")
 In the permission set, click **System Permissions**, then click **Edit**.
 </Step>
 <Step>
-Enable **API Enabled** and **Manage Users**. If using provisioning, also enable **Manage Roles and Role Hierarchy** and **Manage Groups**.
+Enable **API Enabled** and **Manage Users**. If syncing connected apps, also enable **Customize Application**. If using provisioning, also enable **Manage Roles and Role Hierarchy** and **Manage Groups**.
 </Step>
 <Step>
 Click **Save**.
@@ -361,6 +361,7 @@ The connector queries setup objects (User, Profile, UserRole, Group, PermissionS
 | :--- | :--- |
 | API Enabled | Access Salesforce APIs |
 | Manage Users | Read user login status, user records, and related setup objects. This permission automatically includes View Setup and Configuration, View All Users, and other related permissions. |
+| Customize Application | Required only if syncing connected apps (`--sync-connected-apps`). Grants access to query the ConnectedApplication object. |
 
 <Tip>
 **Why is Manage Users required for sync?** The connector queries the UserLogin object to read user frozen/locked status, and Salesforce requires "Manage Users" to access UserLogin even for read-only operations. "Manage Users" also includes "View Setup and Configuration" and "View All Users", which are needed to read Profiles, Roles, Permission Sets, and Groups.


### PR DESCRIPTION
Document required Salesforce object-level permissions for sync and provisioning. The connector queries multiple objects (User, Profile, UserRole, Group, PermissionSet, etc.) and the connector user needs explicit read access to all of them beyond just API Enabled.

Addresses CXP-261 - customers reporting INSUFFICIENT_ACCESS errors despite having API access enabled.

https://claude.ai/code/session_015UCaKChkckW9rBa1AGyFWs

#### Description

- [ ] Bug fix
- [ ] New feature

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
