### PR TITLE
docs: replace e.g. with 'for example'

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -64,7 +64,7 @@ Log into Salesforce as an Administrator. Click the gear icon and select **Setup*
 Search for "permission sets" and select **Permission Sets**.
 </Step>
 <Step>
-Click **New** to create a permission set (e.g., "ConductorOne Connector Access").
+Click **New** to create a permission set (for example, "ConductorOne Connector Access").
 </Step>
 <Step>
 In the permission set, click **System Permissions**, then click **Edit**.


### PR DESCRIPTION
## Summary

The April 7 rebrand PR missed one style issue: a Latin abbreviation in the permission set creation step.

- `(e.g., "ConductorOne Connector Access")` → `(for example, "ConductorOne Connector Access")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)