### PR TITLE
Return Unauthenticated gRPC code for password login failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 dist/
-.monitor-connector.db

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 dist/
+.monitor-connector.db

--- a/pkg/connector/client/salesforce.go
+++ b/pkg/connector/client/salesforce.go
@@ -125,7 +125,7 @@ func (c *SalesforceClient) Initialize(ctx context.Context) error {
 		logger.Debug("Salesforce client using token source")
 		token, err := c.TokenSource.Token()
 		if err != nil {
-			return status.Errorf(codes.Unauthenticated, "failed to get oauth token: %s", err.Error())
+			return err
 		}
 		simpleClient.SetSidLoc(token.AccessToken, c.baseUrl)
 	} else {

--- a/pkg/connector/client/salesforce.go
+++ b/pkg/connector/client/salesforce.go
@@ -14,6 +14,8 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -123,7 +125,7 @@ func (c *SalesforceClient) Initialize(ctx context.Context) error {
 		logger.Debug("Salesforce client using token source")
 		token, err := c.TokenSource.Token()
 		if err != nil {
-			return err
+			return status.Errorf(codes.Unauthenticated, "failed to get oauth token: %s", err.Error())
 		}
 		simpleClient.SetSidLoc(token.AccessToken, c.baseUrl)
 	} else {
@@ -136,7 +138,7 @@ func (c *SalesforceClient) Initialize(ctx context.Context) error {
 		)
 		if err != nil {
 			logger.Error("could not login", zap.Error(err))
-			return err
+			return status.Errorf(codes.Unauthenticated, "could not login: %s", err.Error())
 		}
 	}
 	c.client = simpleClient


### PR DESCRIPTION
## Summary
- The password login path in `Initialize()` returns bare `SalesforceError` with no gRPC status code, causing the sync workflow to treat auth failures (e.g. deactivated user) as transient and retry indefinitely
- Now returns `codes.Unauthenticated` so the sync workflow stops retrying on credential errors
- The OAuth token path is left unchanged — `TokenSource.Token()` already returns properly coded gRPC errors from the control plane (e.g. `FailedPrecondition`), and overriding would mask transient errors that should be retried

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (28 tests across 6 packages)
- [ ] Verify connectors with deactivated service accounts stop retrying after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)