### PR TITLE
Cap Salesforce /query batch size to 200 to avoid lambda timeouts

### DIFF
--- a/pkg/connector/client/ratelimit.go
+++ b/pkg/connector/client/ratelimit.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -11,6 +12,16 @@ import (
 const (
 	RateLimitHeaderKey = "Sforce-Limit-Info"
 	RateLimitFmt       = "api-usage=%d/%d"
+
+	// QueryBatchSize caps the number of records Salesforce returns per /query
+	// batch so the caller's follow-up per-record work (e.g. GetUserLogin)
+	// completes inside a single connector invocation's time budget.
+	// Valid range per Salesforce docs is 200–2000; the header is honored on
+	// the initial /query call and carried through subsequent nextRecordsUrl fetches.
+	QueryBatchSize         = 200
+	QueryOptionsHeaderKey  = "Sforce-Query-Options"
+	queryOptionsBatchSize  = "batchSize=%d"
+	salesforceQueryURLPart = "/services/data/"
 )
 
 // RoundTrip - the simpleforce interface doesn't expose HTTP headers to us, but
@@ -19,6 +30,16 @@ const (
 // value that Salesforce uses to communicate remaining API call counts.
 func (t *salesforceHttpTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	t.rateLimit = nil // clear previous
+
+	// Bound server-side query batch size so per-record follow-up work fits
+	// in one invocation. Applied to the initial /query request; subsequent
+	// nextRecordsUrl fetches inherit the batch size from the initial call.
+	if strings.Contains(request.URL.Path, salesforceQueryURLPart) &&
+		strings.Contains(request.URL.Path, "/query") &&
+		request.Header.Get(QueryOptionsHeaderKey) == "" {
+		request.Header.Set(QueryOptionsHeaderKey, fmt.Sprintf(queryOptionsBatchSize, QueryBatchSize))
+	}
+
 	response, err := t.base.RoundTrip(request)
 	if err != nil {
 		return response, err


### PR DESCRIPTION
## Summary
- Set `Sforce-Query-Options: batchSize=200` on all Salesforce `/query` requests via the existing `salesforceHttpTransport` round tripper.
- Prevents the 5-minute connector invocation deadline from being exceeded on large tenants, where Salesforce's default batch size of 2000 combined with per-record follow-up calls (e.g. `GetUserLogin` in user sync) can stall syncs indefinitely.

## Why
User sync issues a `GetUserLogin` call per user in the page. At the default batch size of 2000 records, a single sync step issues thousands of sequential HTTP requests before returning — exceeding the lambda deadline on tenants with many standard users. Capping the batch at 200 keeps per-invocation work well under the deadline (~200 × 150ms ≈ 30s).

The `Sforce-Query-Options` header is honored on the initial `/query` call and Salesforce bakes the batch size into subsequent `nextRecordsUrl` cursors, so URL-based pagination continues to work unchanged. No changes to resource-syncer code or pagination semantics.

## Trade-off
Larger tenants will now require more connector invocations per sync (one per batch of 200). Follow-up work to eliminate the underlying N+1 in user sync (bulk-fetch `UserLogin` records by user IDs) is worthwhile but out of scope for this hotfix.

## Test plan
- [x] `go test ./...` passes (28 tests across 6 packages)
- [x] `go build ./...` succeeds
- [ ] Verify user sync completes end-to-end on a previously-failing tenant after rollout
- [ ] Confirm no regressions on other resource types (groups, roles, profiles, permissions, permission set groups)