### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -35,7 +35,7 @@ The Salesforce connector supports [automatic account provisioning](/product/admi
 
 This connector does not support account deprovisioning. You must deprovision accounts directly in Salesforce.
 
-**Territories require Enterprise Territory Management 2.0 to be enabled in your Salesforce org. If this feature is not enabled, the connector will return an error when attempting to sync territories.
+**Territories require Enterprise Territory Management 2.0 to be enabled in your Salesforce org. If this feature is not enabled, the connector will return an error when attempting to sync territories.**
 
 ### Optional fields for custom validation rules
 
@@ -73,7 +73,7 @@ Log into Salesforce as an Administrator. Click the gear icon and select **Setup*
 Search for "permission sets" and select **Permission Sets**.
 </Step>
 <Step>
-Click **New** to create a permission set (for example, "ConductorOne Connector Access").
+Click **New** to create a permission set (for example, "C1 Connector Access").
 </Step>
 <Step>
 In the permission set, click **System Permissions**, then click **Edit**.
@@ -108,7 +108,7 @@ Log into the Salesforce admin panel and copy the URL from your browser.
    </Tip>
 </Step>
 </Steps>
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Salesforce connector
 
@@ -201,7 +201,7 @@ Select your method of authenticating to Salesforce and click either **OAuth** or
   </Step>
 </Steps>
 
-**That's it!** Your Salesforce connector is now pulling access data into C1.
+**Done.** Your Salesforce connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the Salesforce connector, hosted and run in your own environment.**
@@ -338,7 +338,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your Salesforce connector is now pulling access data into C1.
+**Done.** Your Salesforce connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

Fixes issues in `docs/connector.mdx` caught during a sync to the ConductorOne docs site:

- Restore `**Done.**` closing phrase (replaces `**That's it!**`)
- Restore `"C1 Connector Access"` as the permission set example name (replaces `"ConductorOne Connector Access"`)
- Fix missing closing `**` on the Territories footnote (formatting bug)

These corrections prevent the sync bot from reintroducing regressions on future runs.